### PR TITLE
Removed dev flag on rebuild script

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -5,4 +5,4 @@ bit64=`php -n -r 'echo PHP_INT_SIZE == 8 ? "1" : "0";'`
 if [[ ${bit64} != "1" ]]; then
 	export CFLAGS="-m32"
 fi
-phpize && ./configure --enable-xdebug-dev && make clean && make all && make install
+phpize && ./configure && make clean && make all && make install


### PR DESCRIPTION
The "dev" flag throws an error when compiling. 